### PR TITLE
basic curie-style resolver for FASP

### DIFF
--- a/src/main/java/org/ga4gh/registry/AppConfig.java
+++ b/src/main/java/org/ga4gh/registry/AppConfig.java
@@ -8,6 +8,7 @@ import org.ga4gh.registry.model.Implementation;
 import org.ga4gh.registry.model.Organization;
 import org.ga4gh.registry.model.Standard;
 import org.ga4gh.registry.model.StandardVersion;
+import org.ga4gh.registry.model.URIResolution;
 import org.ga4gh.registry.util.auth.PlaceholderAuth;
 import org.ga4gh.registry.util.hibernate.HibernateConfig;
 import org.ga4gh.registry.util.hibernate.HibernateUtil;
@@ -19,6 +20,7 @@ import org.ga4gh.registry.util.requesthandler.index.IndexImplementationsHandler;
 import org.ga4gh.registry.util.requesthandler.index.IndexRequestHandler;
 import org.ga4gh.registry.util.requesthandler.index.IndexServiceTypesHandler;
 import org.ga4gh.registry.util.requesthandler.index.IndexServicesHandler;
+import org.ga4gh.registry.util.requesthandler.index.ResolveURIHandler;
 import org.ga4gh.registry.util.requesthandler.post.PostImplementationHandler;
 import org.ga4gh.registry.util.requesthandler.post.PostRequestHandler;
 import org.ga4gh.registry.util.requesthandler.post.PostServiceHandler;
@@ -303,6 +305,17 @@ public class AppConfig implements WebMvcConfigurer {
         return new ShowServiceInfoHandler(Implementation.class, serializerModule, AppConfigConstants.SERVICE_ID);
     }
 
+    /* RESOLVE REQUEST HANDLER BEANS */
+
+    @Bean(name = AppConfigConstants.RESOLVE_URI_HANDLER)
+    @Scope(AppConfigConstants.PROTOTYPE)
+    public ResolveURIHandler resolveURIHandler(
+        // SERIALIZER MODULE GOES HERE
+        @Qualifier(AppConfigConstants.IMPLEMENTATION_HIBERNATE_QUERIER) HibernateQuerier<Implementation> querier
+    ) {
+        return new ResolveURIHandler(Implementation.class, null, querier);
+    }
+
     /* ******************************
      * REQUEST HANDLER FACTORY BEANS
      * ****************************** */
@@ -447,6 +460,14 @@ public class AppConfig implements WebMvcConfigurer {
     @Qualifier(AppConfigConstants.SHOW_SERVICE_INFO_HANDLER_FACTORY)
     public RequestHandlerFactory<Implementation> showServiceInfoHandlerFactory() {
         return new RequestHandlerFactory<>(Implementation.class, AppConfigConstants.SHOW_SERVICE_INFO_HANDLER);
+    }
+
+    /* RESOLVE REQUEST HANDLER FACTORY BEANS */
+
+    @Bean
+    @Qualifier(AppConfigConstants.RESOLVE_URI_HANDLER_FACTORY)
+    public RequestHandlerFactory<URIResolution> resolveURIHandlerFactory() {
+        return new RequestHandlerFactory<>(URIResolution.class, AppConfigConstants.RESOLVE_URI_HANDLER);
     }
 
     /* ******************************

--- a/src/main/java/org/ga4gh/registry/AppConfigConstants.java
+++ b/src/main/java/org/ga4gh/registry/AppConfigConstants.java
@@ -50,6 +50,8 @@ public class AppConfigConstants {
     public static final String INDEX_SERVICE_TYPES_HANDLER = "indexServiceTypesHandler";
     // SERVICE-INFO
     public static final String SHOW_SERVICE_INFO_HANDLER = "showServiceInfoHandler";
+    // RESOLVE
+    public static final String RESOLVE_URI_HANDLER = "resolveURIHandler";
 
     /* ******************************
      * REQUEST HANDLER FACTORY 
@@ -82,6 +84,8 @@ public class AppConfigConstants {
     public static final String INDEX_SERVICE_TYPES_HANDLER_FACTORY = "indexServiceTypesHandlerFactory";
     // SERVICE-INFO
     public static final String SHOW_SERVICE_INFO_HANDLER_FACTORY = "showServiceInfoHandlerFactory";
+    // RESOLVE
+    public static final String RESOLVE_URI_HANDLER_FACTORY = "resolveURIHandlerFactory";
 
     /* ******************************
      * SERIALIZERS

--- a/src/main/java/org/ga4gh/registry/controller/Resolve.java
+++ b/src/main/java/org/ga4gh/registry/controller/Resolve.java
@@ -1,0 +1,31 @@
+package org.ga4gh.registry.controller;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.ga4gh.registry.AppConfigConstants;
+import org.ga4gh.registry.model.URIResolution;
+import org.ga4gh.registry.util.requesthandler.RequestHandlerFactory;
+
+@EnableWebMvc
+@RestController
+@RequestMapping("/resolve-uri")
+public class Resolve {
+
+    @Autowired
+    @Qualifier(AppConfigConstants.RESOLVE_URI_HANDLER_FACTORY)
+    RequestHandlerFactory<URIResolution> resolveURIHandlerFactory;
+
+    @GetMapping(path = "/{uri:.+}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<String> resolveURI(@PathVariable Map<String, String> pathVariables) {
+        return resolveURIHandlerFactory.handleRequest(pathVariables);
+    }
+}

--- a/src/main/java/org/ga4gh/registry/model/Curie.java
+++ b/src/main/java/org/ga4gh/registry/model/Curie.java
@@ -1,0 +1,45 @@
+package org.ga4gh.registry.model;
+
+import java.text.ParseException;
+
+public class Curie {
+
+    private String prefix;
+
+    private String id;
+
+    public static Curie fromString(String curie) throws ParseException {
+        
+        String[] curieSplit = curie.split(":");
+        if (curieSplit.length != 2) {
+            throw new ParseException(curie + " is not in valid CURIE format", 0);
+        }
+        return new Curie(curieSplit[0], curieSplit[1]);
+    }
+
+    /* constructors */
+
+    private Curie(String prefix, String id) {
+        this.prefix = prefix;
+        this.id = id;
+    }
+
+    /* setters and getters */
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+    
+}

--- a/src/main/java/org/ga4gh/registry/model/Implementation.java
+++ b/src/main/java/org/ga4gh/registry/model/Implementation.java
@@ -73,6 +73,9 @@ public class Implementation implements RegistryModel {
     @Column(name = "url")
     private String url;
 
+    @Column(name = "curie_prefix")
+    private String curiePrefix;
+
     @Transient
     private ServiceType type;
 
@@ -205,6 +208,14 @@ public class Implementation implements RegistryModel {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String getCuriePrefix() {
+        return curiePrefix;
+    }
+
+    public void setCuriePrefix(String curiePrefix) {
+        this.curiePrefix = curiePrefix;
     }
 
     public void setType(ServiceType type) {

--- a/src/main/java/org/ga4gh/registry/model/URIResolution.java
+++ b/src/main/java/org/ga4gh/registry/model/URIResolution.java
@@ -1,0 +1,46 @@
+package org.ga4gh.registry.model;
+
+public class URIResolution implements RegistryModel {
+
+    private static final String tableName = "null";
+
+    private String id;
+
+    private String serviceName;
+
+    /* constructors */
+
+    public URIResolution() {
+
+    }
+
+    public URIResolution(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public void lazyLoad() {
+        
+    }
+
+    /* setters and getters */
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+}

--- a/src/main/java/org/ga4gh/registry/util/StaticUtils.java
+++ b/src/main/java/org/ga4gh/registry/util/StaticUtils.java
@@ -1,0 +1,14 @@
+package org.ga4gh.registry.util;
+
+public class StaticUtils {
+
+    public static String addTrailingSlash(String url) {
+        String newURL = url;
+        if (!newURL.endsWith("/")) {
+            newURL += "/";
+        } else {
+        }
+        return newURL;
+    }
+    
+}

--- a/src/main/java/org/ga4gh/registry/util/requesthandler/index/ResolveURIHandler.java
+++ b/src/main/java/org/ga4gh/registry/util/requesthandler/index/ResolveURIHandler.java
@@ -1,0 +1,76 @@
+package org.ga4gh.registry.util.requesthandler.index;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.ga4gh.registry.exception.BadRequestException;
+import org.ga4gh.registry.exception.ResourceNotFoundException;
+import org.ga4gh.registry.model.Curie;
+import org.ga4gh.registry.model.Implementation;
+import org.ga4gh.registry.util.hibernate.HibernateQuerier;
+import org.ga4gh.registry.util.hibernate.HibernateQueryBuilder;
+import org.ga4gh.registry.util.serialize.RegistrySerializerModule;
+import org.ga4gh.registry.util.uriresolver.URIResolver;
+import org.springframework.http.ResponseEntity;
+
+public class ResolveURIHandler extends IndexRequestHandler<Implementation> {
+
+    public ResolveURIHandler(Class<Implementation> responseClass, RegistrySerializerModule serializerModule, HibernateQuerier<Implementation> querier) {
+        super(responseClass, serializerModule, querier);
+    }
+
+    public ResponseEntity<String> createResponseEntity() {
+
+        try {
+            String uriString = getRequestVariablesA().get("uri");
+            Curie curie = Curie.fromString(uriString);
+            Implementation service = getServiceMatchingCuriePrefix(curie.getPrefix());
+            if (service == null) {
+                throw new ResourceNotFoundException("There is no registered service with the CURIE prefix: '" + curie.getPrefix() + "'");
+            }
+
+            String body = resolveURLForService(service, curie.getId());
+
+
+            return ResponseEntity.ok().body(body);
+        } catch (ParseException ex) {
+            throw new BadRequestException(ex.getMessage());
+        }
+    }
+
+    private Implementation getServiceMatchingCuriePrefix(String curiePrefix) {
+        HibernateQuerier<Implementation> q = getQuerier();
+        HibernateQueryBuilder qb = getQueryBuilder();
+        qb.setResponseClass(q.getTypeClass());
+        qb.filter("curiePrefix", curiePrefix);
+        q.setQueryString(qb.build());
+        return q.getSingleResult();
+    }
+
+    private String resolveURLForService(Implementation service, String id) {
+        String resolvedURL = null;
+
+        Map<String, String> resolutionMethodByServiceType = new HashMap<>();
+        resolutionMethodByServiceType.put("org.ga4gh:drs:1.0.0", "drsv1");
+        resolutionMethodByServiceType.put("org.ga4gh:drs:1.1.0", "drsv1");
+
+        try {
+            String methodName = resolutionMethodByServiceType.get(service.getServiceType().signature());
+            URIResolver resolver = new URIResolver();
+            Method method = resolver.getClass().getMethod(methodName, Implementation.class, id.getClass());
+            resolvedURL = (String) method.invoke(resolver, service, id);
+            
+        } catch (NoSuchMethodException ex) {
+            throw new BadRequestException("There is no URI resolution method for this service / service type");
+        } catch (IllegalAccessException ex) {
+            throw new BadRequestException("Could not resolve URI");
+        } catch (InvocationTargetException ex) {
+            throw new BadRequestException("Could not resolve URI");
+        }
+        
+        return resolvedURL;
+    }
+}

--- a/src/main/java/org/ga4gh/registry/util/serialize/serializers/ImplementationSerializer.java
+++ b/src/main/java/org/ga4gh/registry/util/serialize/serializers/ImplementationSerializer.java
@@ -34,6 +34,7 @@ public class ImplementationSerializer extends VariableDepthSerializer<Implementa
         writeObjectIfExists(gen, "createdAt", value.getCreatedAt());
         writeObjectIfExists(gen, "updatedAt", value.getUpdatedAt());
         writeStringIfSelected(gen, "environment", value.getEnvironment());
+        writeStringIfExists(gen, "curiePrefix", value.getCuriePrefix());
         gen.writeEndObject();
 
     }

--- a/src/main/java/org/ga4gh/registry/util/uriresolver/URIResolver.java
+++ b/src/main/java/org/ga4gh/registry/util/uriresolver/URIResolver.java
@@ -1,0 +1,13 @@
+package org.ga4gh.registry.util.uriresolver;
+
+import org.ga4gh.registry.model.Implementation;
+import org.ga4gh.registry.util.StaticUtils;
+
+public class URIResolver {
+
+    public String drsv1(Implementation service, String id) {
+        String resolvedURL = StaticUtils.addTrailingSlash(service.getUrl()) + "ga4gh/drs/v1/objects/" + id;
+        return "{\"resolvedURL\":\"" + resolvedURL + "\"}";
+    }
+    
+}


### PR DESCRIPTION
Experimental feature that allows the resolution of an incoming curie-style id to an object behind a registered GA4GH service. Registered services can be tagged with a unique CURIE prefix, and, when combined with the service's type, allows resolution to an object URL.  